### PR TITLE
replace crazy-max docker metadata

### DIFF
--- a/workflow-templates/build-and-publish-image.yml
+++ b/workflow-templates/build-and-publish-image.yml
@@ -11,14 +11,13 @@ jobs:
     steps:
       - name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
+        uses: docker/metadata-action@v3
         with:
           images: ${{ env.image }}
-          tag-semver: |
-            {{version}}
-            {{major}}.{{minor}}
-            v{{major}}
-          tag-latest: false
+          tags: |
+            type=semver,pattern={{major}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}}
       - name: Login to PDOK Azure Container Registry
         if: startsWith(env.image, 'pdokcr.azurecr.io/')
         uses: docker/login-action@v1


### PR DESCRIPTION
# Omschrijving

Die docker metadata github action [bestaat niet meer](https://github.com/PDOK/delivery-controller/actions/runs/1739379094), is verhuis naar docker.

Tevens zie [discussie over versie tags (met v of zonder) in 3G](https://kadaster-it.slack.com/archives/C01BHSCPYUR/p1635860596005000)

Naar [voorbeeld van de reviewer](https://github.com/PDOK/pdok-reviewer/blob/59e8647196e5009e4fd32ef4c7815d28b4cc271a/.github/workflows/build-and-publish-image.yml).

## Type verandering

- Aanpassing van de configuratie

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [ ] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)